### PR TITLE
General Maintenance & Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
     },
     "require-dev": {
         "twig/twig": "^2.0",
-        "symfony/yaml": "^4.0",
-        "symfony/expression-language": "^4.0",
-        "symfony/framework-bundle": "^4.0",
+        "symfony/yaml": "^4.0 || ^5.0",
+        "symfony/expression-language": "^4.0 || ^5.0",
+        "symfony/framework-bundle": "^4.1 || ^5.0",
         "symfony/phpunit-bridge": "^4.1 || ^5.0",
         "predis/predis": "^1.1",
         "mikey179/vfsstream": "^1.6"

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
     },
     "require-dev": {
         "twig/twig": "^2.0",
-        "symfony/yaml": "^3.2 || ^4.0",
-        "symfony/expression-language": "^3.2 || ^4.0",
-        "symfony/framework-bundle": "^3.2 || ^4.0",
+        "symfony/yaml": "^4.0",
+        "symfony/expression-language": "^4.0",
+        "symfony/framework-bundle": "^4.0",
         "symfony/phpunit-bridge": "^4.1 || ^5.0",
         "predis/predis": "^1.1",
         "mikey179/vfsstream": "^1.6"

--- a/src/Symfony/Command/ToggleGetCommand.php
+++ b/src/Symfony/Command/ToggleGetCommand.php
@@ -13,22 +13,36 @@ declare(strict_types=1);
 
 namespace SolidWorx\Toggler\Symfony\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use SolidWorx\Toggler\ToggleInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ToggleGetCommand extends ContainerAwareCommand
+class ToggleGetCommand extends Command
 {
+    protected static $defaultName = 'toggler:get';
+
+    /**
+     * @var ToggleInterface
+     */
+    private $toggle;
+
+    public function __construct(ToggleInterface $toggle)
+    {
+        $this->toggle = $toggle;
+
+        parent::__construct();
+    }
+
     /**
      * {@inheritdoc}
      */
     protected function configure()
     {
-        $this->setName('toggler:get')
-            ->setDescription('Get the status of a specific feature')
+        $this->setDescription('Get the status of a specific feature')
             ->addArgument('feature', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'The feature to get the status')
             ->addOption('context', 'c', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Add context to the feature check')
             ->setHelp(<<<'HELP'
@@ -55,10 +69,6 @@ HELP
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $container = $this->getContainer();
-
-        $toggle = $container->get('toggler.toggle');
-
         $features = $input->getArgument('feature');
 
         $context = [];
@@ -84,7 +94,7 @@ HELP
         $table->setHeaders($headers);
 
         foreach ($features as $feature) {
-            $active = $toggle->isActive($feature, $context);
+            $active = $this->toggle->isActive($feature, $context);
 
             $row = [
                 $feature,

--- a/src/Symfony/Command/ToggleSetCommand.php
+++ b/src/Symfony/Command/ToggleSetCommand.php
@@ -15,13 +15,15 @@ namespace SolidWorx\Toggler\Symfony\Command;
 
 use SolidWorx\Toggler\Storage\PersistenStorageInterface;
 use SolidWorx\Toggler\Storage\StorageInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ToggleSetCommand extends ContainerAwareCommand
+class ToggleSetCommand extends Command
 {
+    protected static $defaultName = 'toggler:set';
+
     private $storage;
 
     public function __construct(StorageInterface $storage)
@@ -36,8 +38,7 @@ class ToggleSetCommand extends ContainerAwareCommand
      */
     protected function configure()
     {
-        $this->setName('toggler:set')
-            ->setDescription('Change the status of a specific feature')
+        $this->setDescription('Change the status of a specific feature')
             ->addArgument('feature', InputArgument::REQUIRED, 'The feature to change the status')
             ->addArgument('value', InputArgument::REQUIRED, 'The status to set the feature to (can be either true|false or 1|0)')
             ->setHelp(<<<'HELP'

--- a/src/Symfony/DependencyInjection/Configuration.php
+++ b/src/Symfony/DependencyInjection/Configuration.php
@@ -24,14 +24,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('toggler');
+        $treeBuilder = new TreeBuilder('toggler');
+        $rootNode = $treeBuilder->getRootNode();
 
-        $node = $rootNode
+        $rootNode
             ->children()
                 ->arrayNode('config')
                     ->isRequired()
-                    ->cannotBeEmpty()
                     ->children()
                         ->scalarNode('storage')
                             ->info('Set the storage handler service')

--- a/src/Symfony/DependencyInjection/TogglerExtension.php
+++ b/src/Symfony/DependencyInjection/TogglerExtension.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace SolidWorx\Toggler\Symfony\DependencyInjection;
 
 use SolidWorx\Toggler\Storage\StorageFactory;
+use SolidWorx\Toggler\Symfony\Command\ToggleSetCommand;
+use SolidWorx\Toggler\Toggle;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -36,8 +38,8 @@ class TogglerExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
-        $definition = $container->getDefinition('toggler.toggle');
-        $commandDefinition = $container->getDefinition('toggler.command.set_value');
+        $definition = $container->getDefinition(Toggle::class);
+        $commandDefinition = $container->getDefinition(ToggleSetCommand::class);
 
         if (!empty($config['config']['storage'])) {
             $service = $config['config']['storage'];

--- a/src/Symfony/Resources/config/services.yml
+++ b/src/Symfony/Resources/config/services.yml
@@ -8,42 +8,44 @@
  ##
 
 services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
 
-    toggler.command.set_value:
-        class: SolidWorx\Toggler\Symfony\Command\ToggleSetCommand
+    SolidWorx\Toggler\Symfony\Command\:
+        resource: '../../Command/'
+
+    SolidWorx\Toggler\Symfony\Command\ToggleSetCommand:
         arguments: ['?']
-        tags:
-            - { name: console.command }
 
-    toggler.expression.language.provider.dependency_injection:
-        class: Symfony\Component\DependencyInjection\ExpressionLanguageProvider
+    SolidWorx\Toggler\Symfony\Command\ToggleGetCommand:
+        arguments:
+            $toggle: '@SolidWorx\Toggler\Toggle'
+
+    Symfony\Component\DependencyInjection\ExpressionLanguageProvider:
         public: false
 
-    toggler.expression.language.provider.security:
-        class: Symfony\Component\Security\Core\Authorization\ExpressionLanguageProvider
+    Symfony\Component\Security\Core\Authorization\ExpressionLanguageProvider:
         public: false
 
-    toggler.expression.language:
-        class: Symfony\Component\ExpressionLanguage\ExpressionLanguage
+    Symfony\Component\ExpressionLanguage\ExpressionLanguage:
         public: false
         calls:
-            - ['registerProvider', ['@toggler.expression.language.provider.dependency_injection']]
-            - ['registerProvider', ['@toggler.expression.language.provider.security']]
+            - ['registerProvider', ['@Symfony\Component\DependencyInjection\ExpressionLanguageProvider']]
+            - ['registerProvider', ['@Symfony\Component\Security\Core\Authorization\ExpressionLanguageProvider']]
 
-    toggler.toggle:
-        class: SolidWorx\Toggler\Toggle
-        arguments: ['?', '@toggler.expression.language']
+    SolidWorx\Toggler\Toggle:
+        arguments: ['?', '@Symfony\Component\ExpressionLanguage\ExpressionLanguage']
 
-    toggler.symfony.toggle:
-        class: SolidWorx\Toggler\Symfony\Toggle
-        decorates: toggler.toggle
+    SolidWorx\Toggler\Symfony\Toggle:
+        decorates: 'SolidWorx\Toggler\Toggle'
         public: false
-        arguments: ['@toggler.symfony.toggle.inner']
+        arguments:
+            $toggle: '@SolidWorx\Toggler\Symfony\Toggle.inner'
         calls:
             - ['setContainer', ['@service_container']]
 
-    toggler.twig.extension:
-        class: SolidWorx\Toggler\Twig\Extension\ToggleExtension
-        arguments: ['@toggler.toggle']
+    SolidWorx\Toggler\Twig\Extension\ToggleExtension:
+        arguments: ['@Solidworx\Toggler\Toggle']
         tags:
             - { name: twig.extension }


### PR DESCRIPTION
### Symfony 4 Compatibility Updates 
- Updated minimum versions for Symfony packages to 4.0
- Removed cannotBeEmpty from ArrayNode in storage configuration definition 