### PR TITLE
Bump up minimum twig version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": ">=7.1.0"
     },
     "require-dev": {
-        "twig/twig": "^2.0",
+        "twig/twig": "^2.7 || ^3.0",
         "symfony/yaml": "^3.2 || ^4.0",
         "symfony/expression-language": "^3.2 || ^4.0",
         "symfony/framework-bundle": "^3.2 || ^4.0",

--- a/src/Twig/Extension/ToggleExtension.php
+++ b/src/Twig/Extension/ToggleExtension.php
@@ -15,8 +15,10 @@ namespace SolidWorx\Toggler\Twig\Extension;
 
 use SolidWorx\Toggler\ToggleInterface;
 use SolidWorx\Toggler\Twig\Parser\ToggleTokenParser;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class ToggleExtension extends \Twig_Extension
+class ToggleExtension extends AbstractExtension
 {
     /**
      * @var ToggleInterface
@@ -47,7 +49,7 @@ class ToggleExtension extends \Twig_Extension
     public function getFunctions(): array
     {
         return [
-            new \Twig_SimpleFunction('toggle', [$this->toggle, 'isActive']),
+            new TwigFunction('toggle', [$this->toggle, 'isActive']),
         ];
     }
 

--- a/src/Twig/Node/ToggleNode.php
+++ b/src/Twig/Node/ToggleNode.php
@@ -13,14 +13,17 @@ declare(strict_types=1);
 
 namespace SolidWorx\Toggler\Twig\Node;
 
-class ToggleNode extends \Twig_Node
+use Twig\Compiler;
+use Twig\Node\Node;
+
+class ToggleNode extends Node
 {
     /**
      * @param \Twig_Node $else
      * @param \Twig_Node $variables
      * @param string     $tag
      */
-    public function __construct(\Twig_Node $feature, \Twig_Node $body, ?\Twig_Node $else, ?\Twig_Node $variables, int $lineNo, string $tag = null)
+    public function __construct(Node $feature, Node $body, ?Node $else, ?Node $variables, int $lineNo, string $tag = null)
     {
         $nodes = [
             'feature' => $feature,
@@ -41,9 +44,9 @@ class ToggleNode extends \Twig_Node
     /**
      * Compiles the node to PHP.
      *
-     * @param \Twig_Compiler $compiler A Twig_Compiler instance
+     * @param Compiler $compiler A Twig_Compiler instance
      */
-    public function compile(\Twig_Compiler $compiler): void
+    public function compile(Compiler $compiler): void
     {
         $compiler->addDebugInfo($this);
 

--- a/tests/Twig/Extension/Node/ToggleNodeTest.php
+++ b/tests/Twig/Extension/Node/ToggleNodeTest.php
@@ -14,25 +14,32 @@ declare(strict_types=1);
 namespace SolidWorx\Tests\Toggler\Twig\Extension\Node;
 
 use SolidWorx\Toggler\Twig\Node\ToggleNode;
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\NameExpression;
+use Twig\Node\Node;
+use Twig\Node\PrintNode;
+use Twig\Node\TextNode;
+use Twig\Test\NodeTestCase;
 
-if (class_exists('Twig_Test_NodeTestCase')) {
-    class ToggleNodeTest extends \Twig_Test_NodeTestCase
+if (class_exists(NodeTestCase::class)) {
+    class ToggleNodeTest extends NodeTestCase
     {
         public function testConstructor()
         {
-            $t = new \Twig_Node([
-                new \Twig_Node_Expression_Constant(true, 1),
-                new \Twig_Node_Print(new \Twig_Node_Expression_Name('foo', 1), 1),
+            $t = new Node([
+                new ConstantExpression(true, 1),
+                new PrintNode(new NameExpression('foo', 1), 1),
             ], [], 1);
             $else = null;
-            $node = new ToggleNode(new \Twig_Node_Text('foo', 1), $t, $else, null, 1, null);
+            $node = new ToggleNode(new TextNode('foo', 1), $t, $else, null, 1, null);
 
             $this->assertEquals($t, $node->getNode('body'));
-            $this->assertEquals(new \Twig_Node_Text('foo', 1), $node->getNode('feature'));
+            $this->assertEquals(new TextNode('foo', 1), $node->getNode('feature'));
             $this->assertFalse($node->hasNode('else'));
 
-            $else = new \Twig_Node_Print(new \Twig_Node_Expression_Name('bar', 1), 1);
-            $node = new ToggleNode(new \Twig_Node_Text('bar', 1), $t, $else, null, 1, null);
+            $else = new PrintNode(new NameExpression('bar', 1), 1);
+            $node = new ToggleNode(new TextNode('bar', 1), $t, $else, null, 1, null);
             $this->assertEquals($else, $node->getNode('else'));
         }
 
@@ -49,11 +56,11 @@ if (class_exists('Twig_Test_NodeTestCase')) {
 
         private function getToggleTest(): array
         {
-            $t = new \Twig_Node([
-                new \Twig_Node_Print(new \Twig_Node_Expression_Name('foo', 1), 1),
-            ], [], null, 1);
+            $t = new Node([
+                new PrintNode(new NameExpression('foo', 1), 1),
+            ], [], 1, null);
             $else = null;
-            $node = new ToggleNode(new \Twig_Node([new \Twig_Node_Expression_Constant('foo', 1)]), $t, $else, null, 1);
+            $node = new ToggleNode(new Node([new ConstantExpression('foo', 1)]), $t, $else, null, 1);
 
             return [
                 $node,
@@ -69,11 +76,11 @@ EOF
 
         private function getToggleWithElseTest(): array
         {
-            $t = new \Twig_Node([
-                new \Twig_Node_Print(new \Twig_Node_Expression_Name('foo', 1), 1),
-            ], [], null, 1);
-            $else = new \Twig_Node_Print(new \Twig_Node_Expression_Name('bar', 1), 1);
-            $node = new ToggleNode(new \Twig_Node([new \Twig_Node_Expression_Constant('foo', 1)]), $t, $else, null, 1);
+            $t = new Node([
+                new PrintNode(new NameExpression('foo', 1), 1),
+            ], [], 1, null);
+            $else = new PrintNode(new NameExpression('bar', 1), 1);
+            $node = new ToggleNode(new Node([new ConstantExpression('foo', 1)]), $t, $else, null, 1);
 
             return [
                 $node,
@@ -91,14 +98,14 @@ EOF
 
         private function getToggleWithContextTest(): array
         {
-            $t = new \Twig_Node([
-                new \Twig_Node_Print(new \Twig_Node_Expression_Name('foo', 1), 1),
-            ], [], null, 1);
+            $t = new Node([
+                new PrintNode(new NameExpression('foo', 1), 1),
+            ], [], 1, null);
 
-            $node = new ToggleNode(new \Twig_Node([new \Twig_Node_Expression_Constant('foo', 1)]),
+            $node = new ToggleNode(new Node([new ConstantExpression('foo', 1)]),
                 $t,
                 null,
-                new \Twig_Node_Expression_Array([new \Twig_Node_Expression_Constant('value1', 1), new \Twig_Node_Expression_Constant(12, 1)], 1),
+                new ArrayExpression([new ConstantExpression('value1', 1), new ConstantExpression(12, 1)], 1),
                 1
             );
 
@@ -106,7 +113,7 @@ EOF
                 $node,
                 <<<EOF
 // line 1
-if (\$this->env->getExtension('SolidWorx\Toggler\Twig\Extension\ToggleExtension')->getToggle()->isActive("foo", array("value1" => 12))) {
+if (\$this->env->getExtension('SolidWorx\Toggler\Twig\Extension\ToggleExtension')->getToggle()->isActive("foo", ["value1" => 12])) {
     echo {$this->getVariableGetter('foo')};
 }
 EOF


### PR DESCRIPTION
### Update Twig 
Since twig 2.0.0 up to 2.6.2 all have the Sandbox mode security vulnerability, I took a bit of time to:
- Bump the minimum required twig version from ^2.0 to ^2.7
- Fix Deprecation Warnings that came as a result of requiring Twig 2.7 or higher

Security Advisory link: https://symfony.com/blog/twig-sandbox-information-disclosure 