### PR TITLE
Fix more Symfony related issues

### DIFF
--- a/src/Symfony/Resources/config/services.yml
+++ b/src/Symfony/Resources/config/services.yml
@@ -22,20 +22,23 @@ services:
         arguments:
             $toggle: '@SolidWorx\Toggler\Toggle'
 
-    Symfony\Component\DependencyInjection\ExpressionLanguageProvider:
+    toggler.expression.language.provider.dependency_injection:
+        class: Symfony\Component\DependencyInjection\ExpressionLanguageProvider
         public: false
 
-    Symfony\Component\Security\Core\Authorization\ExpressionLanguageProvider:
+    toggler.expression.language.provider.security:
+        class: Symfony\Component\Security\Core\Authorization\ExpressionLanguageProvider
         public: false
 
-    Symfony\Component\ExpressionLanguage\ExpressionLanguage:
+    toggler.expression.language:
+        class: Symfony\Component\ExpressionLanguage\ExpressionLanguage
         public: false
         calls:
-            - ['registerProvider', ['@Symfony\Component\DependencyInjection\ExpressionLanguageProvider']]
-            - ['registerProvider', ['@Symfony\Component\Security\Core\Authorization\ExpressionLanguageProvider']]
+            - ['registerProvider', ['@toggler.expression.language.provider.dependency_injection']]
+            - ['registerProvider', ['@toggler.expression.language.provider.security']]
 
     SolidWorx\Toggler\Toggle:
-        arguments: ['?', '@Symfony\Component\ExpressionLanguage\ExpressionLanguage']
+        arguments: ['?', '@toggler.expression.language']
 
     SolidWorx\Toggler\Symfony\Toggle:
         decorates: 'SolidWorx\Toggler\Toggle'
@@ -46,6 +49,6 @@ services:
             - ['setContainer', ['@service_container']]
 
     SolidWorx\Toggler\Twig\Extension\ToggleExtension:
-        arguments: ['@Solidworx\Toggler\Toggle']
+        arguments: ['@SolidWorx\Toggler\Toggle']
         tags:
             - { name: twig.extension }

--- a/src/Symfony/Toggle.php
+++ b/src/Symfony/Toggle.php
@@ -17,6 +17,7 @@ use SolidWorx\Toggler\Toggle as BaseToggle;
 use SolidWorx\Toggler\ToggleInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\Security\Core\Role\Role;
 
 final class Toggle implements ToggleInterface, ContainerAwareInterface
 {
@@ -53,7 +54,7 @@ final class Toggle implements ToggleInterface, ContainerAwareInterface
             self::$variables = [
                 'token' => $token,
                 'request' => $request,
-                'roles' => array_map(function (RoleInterface $role) {
+                'roles' => array_map(static function (Role $role) {
                     return $role->getRole();
                 }, $roles),
                 'trust_resolver' => $this->container->get('security.authentication.trust_resolver'),


### PR DESCRIPTION
### Symfony Integration
- Fix incorrect expression service definitions, and fixed typo in twig extension service definition argument
- Updated Symfony Toggler error in expression language context on Symfony 5 where RoleInterface has been removed.  