### PR TITLE
Explicitly add injected service name in service definition, and set default value for variables

### DIFF
--- a/src/Symfony/Resources/config/services.yml
+++ b/src/Symfony/Resources/config/services.yml
@@ -45,6 +45,8 @@ services:
         public: false
         arguments:
             $toggle: '@SolidWorx\Toggler\Symfony\Toggle.inner'
+            $roleHierarchy: '@security.role_hierarchy'
+            $trustResolver: '@security.authentication.trust_resolver'
         calls:
             - ['setContainer', ['@service_container']]
 

--- a/src/Symfony/Toggle.php
+++ b/src/Symfony/Toggle.php
@@ -96,11 +96,10 @@ final class Toggle implements ToggleInterface, ContainerAwareInterface
             $roles = [];
 
             if ($token instanceof TokenInterface) {
-                if (method_exists($this->roleHierarchy, 'getReachableRoleNames')) {
-                $roles = $this->roleHierarchy->getReachableRoleNames($token->getRoleNames());
-                } else {
-                    $roles = $this->roleHierarchy->getReachableRoles($token->getRoles());
-                }
+                $rolesArray = method_exists($token, 'getRoles') ? $token->getRoles() : $token->getRoleNames();
+                $roles = method_exists($this->roleHierarchy, 'getReachableRoles')
+                    ? $this->roleHierarchy->getReachableRoles($rolesArray)
+                    : $this->roleHierarchy->getReachableRoleNames($rolesArray);
             }
 
             self::$variables = [

--- a/src/Symfony/Toggle.php
+++ b/src/Symfony/Toggle.php
@@ -33,7 +33,7 @@ final class Toggle implements ToggleInterface, ContainerAwareInterface
     /**
      * @var array<mixed>
      */
-    private static $variables;
+    private static $variables = [];
 
     /**
      * @var BaseToggle
@@ -96,7 +96,11 @@ final class Toggle implements ToggleInterface, ContainerAwareInterface
             $roles = [];
 
             if ($token instanceof TokenInterface) {
+                if (method_exists($this->roleHierarchy, 'getReachableRoleNames')) {
                 $roles = $this->roleHierarchy->getReachableRoleNames($token->getRoleNames());
+                } else {
+                    $roles = $this->roleHierarchy->getReachableRoles($token->getRoles());
+                }
             }
 
             self::$variables = [


### PR DESCRIPTION
### Fixes: 
* Explicitly specify services that has no alias in Symfony, for Symfony Toggler service definition
* Check if roleHierarchy->getReachableRoleNames exists, otherwise call roleHierarchy->getReachableRoles (compatibility for Symfony 4 & Symfony 5)