### PR TITLE
Fix using expressions in config

### DIFF
--- a/src/Symfony/DependencyInjection/TogglerExtension.php
+++ b/src/Symfony/DependencyInjection/TogglerExtension.php
@@ -80,7 +80,7 @@ class TogglerExtension extends Extension
                         throw new InvalidArgumentException('The symfony/expression-language component is required in order to use expressions.');
                     }
 
-                    $value = new Definition(Expression::class, [substr($value, 2)]);
+                    $value = new Expression(substr($value, 2));
                     break;
             }
         }

--- a/src/Symfony/Resources/config/services.yml
+++ b/src/Symfony/Resources/config/services.yml
@@ -39,7 +39,6 @@ services:
         class: Symfony\Component\ExpressionLanguage\ExpressionLanguage
         public: false
         calls:
-            - ['registerProvider', ['@toggler.expression.language.provider.dependency_injection']]
             - ['registerProvider', ['@toggler.expression.language.provider.security']]
 
     SolidWorx\Toggler\Toggle:


### PR DESCRIPTION
When using an expression in the Symfony yaml config, the expression was created and evaluated at runtime and missing out on container features. Instead, we can compile the expression so that it gets cached inside the container cache, improving performance slightly and ensuring accessing information from the container works

E.G, the below did not work, as there was no way to get the env var. With this change, it uses the container config to get the env value

```yaml
toggler:
    config:
        features:
            foo: '@=env('my_env_var') == 'some-value'
```